### PR TITLE
Fixed ForestDB store native crash issue

### DIFF
--- a/jni/cbforest.i
+++ b/jni/cbforest.i
@@ -381,7 +381,18 @@
     return $null;
    }
 }
-
+// VersionedDocument
+%javaexception("java.lang.Exception") VersionedDocument {
+  try {
+     $action
+  } catch (forestdb::error err) {
+    jclass clazz = jenv->FindClass("java/lang/Exception");
+    char buff[64];
+    sprintf(buff, "%d", err.status);
+    jenv->ThrowNew(clazz, buff);
+    return $null;
+   }
+}
 /**
  * Mappable 
  * NOTE: Mappable is extended Java side, and is passed as parameter from native to java.

--- a/jni/cbforest_wrap.cc
+++ b/jni/cbforest_wrap.cc
@@ -6122,7 +6122,17 @@ SWIGEXPORT jlong JNICALL Java_com_couchbase_lite_cbforest_cbforestJNI_new_1Versi
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "CBF::Slice & reference is null");
     return 0;
   } 
-  result = (CBF::VersionedDocument *)new CBF::VersionedDocument(*arg1,*arg2);
+  {
+    try {
+      result = (CBF::VersionedDocument *)new CBF::VersionedDocument(*arg1,*arg2);
+    } catch (forestdb::error err) {
+      jclass clazz = jenv->FindClass("java/lang/Exception");
+      char buff[64];
+      sprintf(buff, "%d", err.status);
+      jenv->ThrowNew(clazz, buff);
+      return 0;
+    }
+  }
   *(CBF::VersionedDocument **)&jresult = result; 
   return jresult;
 }
@@ -6148,7 +6158,17 @@ SWIGEXPORT jlong JNICALL Java_com_couchbase_lite_cbforest_cbforestJNI_new_1Versi
     SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "CBF::Document const & reference is null");
     return 0;
   } 
-  result = (CBF::VersionedDocument *)new CBF::VersionedDocument(*arg1,(CBF::Document const &)*arg2);
+  {
+    try {
+      result = (CBF::VersionedDocument *)new CBF::VersionedDocument(*arg1,(CBF::Document const &)*arg2);
+    } catch (forestdb::error err) {
+      jclass clazz = jenv->FindClass("java/lang/Exception");
+      char buff[64];
+      sprintf(buff, "%d", err.status);
+      jenv->ThrowNew(clazz, buff);
+      return 0;
+    }
+  }
   *(CBF::VersionedDocument **)&jresult = result; 
   return jresult;
 }

--- a/src/main/java/com/couchbase/lite/cbforest/VersionedDocument.java
+++ b/src/main/java/com/couchbase/lite/cbforest/VersionedDocument.java
@@ -35,11 +35,11 @@ public class VersionedDocument extends RevTree {
     super.delete();
   }
 
-  public VersionedDocument(KeyStore arg0, Slice arg1) {
+  public VersionedDocument(KeyStore arg0, Slice arg1) throws java.lang.Exception {
     this(cbforestJNI.new_VersionedDocument__SWIG_0(KeyStore.getCPtr(arg0), arg0, Slice.getCPtr(arg1), arg1), true);
   }
 
-  public VersionedDocument(KeyStore arg0, Document arg1) {
+  public VersionedDocument(KeyStore arg0, Document arg1) throws java.lang.Exception {
     this(cbforestJNI.new_VersionedDocument__SWIG_1(KeyStore.getCPtr(arg0), arg0, Document.getCPtr(arg1), arg1), true);
   }
 

--- a/src/main/java/com/couchbase/lite/cbforest/cbforestJNI.java
+++ b/src/main/java/com/couchbase/lite/cbforest/cbforestJNI.java
@@ -269,8 +269,8 @@ public class cbforestJNI {
   public final static native int VersionedDocument_kDeleted_get();
   public final static native int VersionedDocument_kConflicted_get();
   public final static native int VersionedDocument_kHasAttachments_get();
-  public final static native long new_VersionedDocument__SWIG_0(long jarg1, KeyStore jarg1_, long jarg2, Slice jarg2_);
-  public final static native long new_VersionedDocument__SWIG_1(long jarg1, KeyStore jarg1_, long jarg2, Document jarg2_);
+  public final static native long new_VersionedDocument__SWIG_0(long jarg1, KeyStore jarg1_, long jarg2, Slice jarg2_) throws java.lang.Exception;
+  public final static native long new_VersionedDocument__SWIG_1(long jarg1, KeyStore jarg1_, long jarg2, Document jarg2_) throws java.lang.Exception;
   public final static native void delete_VersionedDocument(long jarg1);
   public final static native void VersionedDocument_read(long jarg1, VersionedDocument jarg1_) throws java.lang.Exception;
   public final static native boolean VersionedDocument_revsAvailable(long jarg1, VersionedDocument jarg1_);

--- a/src/main/java/com/couchbase/lite/store/ForestDBStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBStore.java
@@ -319,7 +319,13 @@ public class ForestDBStore implements Store {
         RevisionInternal result = null;
 
         // TODO: add VersionDocument(Database, String)
-        VersionedDocument doc = new VersionedDocument(forest, new Slice(docID.getBytes()));
+        VersionedDocument doc = null;
+        try {
+            doc = new VersionedDocument(forest, new Slice(docID.getBytes()));
+        } catch (Exception e) {
+            Log.e(TAG, "ForestDB Error: " + e.getMessage(), e);
+            return null;
+        }
         if(!doc.exists()) {
             doc.delete();
             //throw new CouchbaseLiteException(Status.NOT_FOUND);
@@ -380,7 +386,13 @@ public class ForestDBStore implements Store {
             return null;
 
         RevisionInternal parent = null;
-        VersionedDocument doc = new VersionedDocument(forest, new Slice(rev.getDocID().getBytes()));
+        VersionedDocument doc = null;
+        try {
+            doc = new VersionedDocument(forest, new Slice(rev.getDocID().getBytes()));
+        } catch (Exception e) {
+            Log.w(TAG, "ForestDB Error: " + e.getMessage(), e);
+        }
+
         if(doc != null) {
             Revision revNode = null;
             try {
@@ -422,7 +434,13 @@ public class ForestDBStore implements Store {
     public RevisionList getAllRevisions(String docID, boolean onlyCurrent) {
 
         // TODO: add VersionDocument(Database, String)
-        VersionedDocument doc = new VersionedDocument(forest, new Slice(docID.getBytes()));
+        VersionedDocument doc = null;
+        try {
+            doc = new VersionedDocument(forest, new Slice(docID.getBytes()));
+        } catch (Exception e) {
+            Log.w(TAG, "ForestDB Error: " + e.getMessage(), e);
+            return null;
+        }
         if(!doc.exists()) {
             doc.delete();
             //throw new CouchbaseLiteException(Status.NOT_FOUND);
@@ -452,7 +470,13 @@ public class ForestDBStore implements Store {
         if(generation <= 1)
             return null;
 
-        VersionedDocument doc = new VersionedDocument(forest, new Slice(rev.getDocID().getBytes()));
+        VersionedDocument doc = null;
+        try {
+            doc = new VersionedDocument(forest, new Slice(rev.getDocID().getBytes()));
+        } catch (Exception e) {
+            Log.w(TAG, "ForestDB Error: " + e.getMessage(), e);
+            return null;
+        }
         if(doc == null)
             return null;
         List<String> revIDs = new ArrayList<String>();
@@ -512,7 +536,13 @@ public class ForestDBStore implements Store {
                 if (doc != null) {
                     doc.delete();
                 }
-                doc = new VersionedDocument(forest, new Slice(lastDocID.getBytes()));
+                try {
+                    doc = new VersionedDocument(forest, new Slice(lastDocID.getBytes()));
+                } catch (Exception e) {
+                    Log.w(TAG, "ForestDB Error: " + e.getMessage(), e);
+                    doc = null;
+                }
+
                 if (doc != null) {
                     try {
                         if (doc.get(new RevIDBuffer(new Slice(rev.getRevID().getBytes()))) != null) {
@@ -825,7 +855,13 @@ public class ForestDBStore implements Store {
             }
 
             // Parse the document revision tree:
-            VersionedDocument doc = new VersionedDocument(forest, rawDoc);
+            VersionedDocument doc = null;
+            try {
+                doc = new VersionedDocument(forest, rawDoc);
+            } catch (Exception e) {
+                Log.e(TAG, "ForestDB Error: " + e.getMessage(), e);
+                throw new CouchbaseLiteException(Status.EXCEPTION);
+            }
             Revision revNode;
 
             if (prevRevID != null) {
@@ -948,7 +984,13 @@ public class ForestDBStore implements Store {
             @Override
             public Status run() {
                 // First get the CBForest doc:
-                VersionedDocument doc = new VersionedDocument(forest, new Slice(rev.getDocID().getBytes()));
+                VersionedDocument doc = null;
+                try {
+                    doc = new VersionedDocument(forest, new Slice(rev.getDocID().getBytes()));
+                } catch (Exception e) {
+                    Log.e(TAG, "ForestDB Error: " + e.getMessage(), e);
+                    return new Status(Status.UNKNOWN);
+                }
 
                 // Add the revision & ancestry to the doc:
                 VectorRevID historyVector = new VectorRevID();
@@ -1009,7 +1051,13 @@ public class ForestDBStore implements Store {
             @Override
             public Status run() {
                 for (String docID : docsToRevs.keySet()) {
-                    VersionedDocument doc = new VersionedDocument(forest, new Slice(docID.getBytes()));
+                    VersionedDocument doc = null;
+                    try {
+                        doc = new VersionedDocument(forest, new Slice(docID.getBytes()));
+                    } catch (Exception e) {
+                        Log.e(TAG, "ForestDB Error: " + e.getMessage(), e);
+                        return new Status(Status.UNKNOWN);
+                    }
                     if(!doc.exists())
                         return new Status(Status.NOT_FOUND);
 

--- a/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
@@ -137,7 +137,14 @@ public class ForestDBViewStore  implements ViewStore, QueryRowStore{
             }
 
             if (indexIt) {
-                VersionedDocument vdoc = new VersionedDocument(sourceStore, cppDoc);
+                VersionedDocument vdoc = null;
+                try {
+                    vdoc = new VersionedDocument(sourceStore, cppDoc);
+                } catch (Exception e) {
+                    Log.e(TAG, "ForestDB Error: " + e.getMessage(), e);
+                    return;
+                }
+
                 Revision node = vdoc.currentRevision();
                 Map<String, Object> body = ForestBridge.bodyOfNode(node, vdoc);
                 body.put("_local_seq", node.getSequence().longValue());


### PR DESCRIPTION
Ticket: https://github.com/couchbase/couchbase-lite-java-core/issues/750

Details: VersionedDocument throws exception if forestdb returns error. But, JNI binding code for VersionedDocument did not catch exception. To catch exception in JNI binding and to throw java Exception to Java caller codes addressed the crash in native library.
