### PR TITLE
Fixed issue #9 Clean generated JNI headers after build

### DIFF
--- a/build-android.gradle
+++ b/build-android.gradle
@@ -82,6 +82,9 @@ android {
     }
 
     buildNative.dependsOn 'generateJniHeaders'
+    buildNative.doLast {
+        cleanJniHeaders.execute()
+    }
 
     task cleanNative(type: Exec, description: 'Clean JNI object files') {
         def ndkDir = android.ndkDirectory

--- a/build-java.gradle
+++ b/build-java.gradle
@@ -53,6 +53,11 @@ task cleanJniHeaders(type: Delete, description: 'Clean JNI C header files') {
     delete "vendor/cbforest/Java/jni/com_couchbase_cbforest_View.h"
 }
 clean.dependsOn 'cleanJniHeaders'
+
+build.doLast {
+    cleanJniHeaders.execute()
+}
+
 model {
     platforms {
         osx_x86 {


### PR DESCRIPTION
Removed generated JNI headers in vendor/cbforest submodule after build so that the cbforest submodule doesn't have any untracked files left
