### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-java-core/issues/818

### DIFF
--- a/src/main/java/com/couchbase/lite/store/ForestDBStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBStore.java
@@ -585,7 +585,10 @@ public class ForestDBStore implements Store, Constants {
         if (options == null)
             options = new QueryOptions();
 
-        boolean includeDocs = (options.isIncludeDocs() || options.getPostFilter() != null);
+        boolean includeDocs = (options.isIncludeDocs() ||
+                options.getPostFilter() != null ||
+                options.getAllDocsMode() == Query.AllDocsMode.SHOW_CONFLICTS ||
+                options.getAllDocsMode() == Query.AllDocsMode.ONLY_CONFLICTS);
         boolean includeDeletedDocs = (options.getAllDocsMode() == Query.AllDocsMode.INCLUDE_DELETED);
         int limit = options.getLimit();
         int skip = options.getSkip();

--- a/src/main/java/com/couchbase/lite/store/ForestDBStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBStore.java
@@ -587,8 +587,7 @@ public class ForestDBStore implements Store, Constants {
 
         boolean includeDocs = (options.isIncludeDocs() ||
                 options.getPostFilter() != null ||
-                options.getAllDocsMode() == Query.AllDocsMode.SHOW_CONFLICTS ||
-                options.getAllDocsMode() == Query.AllDocsMode.ONLY_CONFLICTS);
+                options.getAllDocsMode() == Query.AllDocsMode.SHOW_CONFLICTS);
         boolean includeDeletedDocs = (options.getAllDocsMode() == Query.AllDocsMode.INCLUDE_DELETED);
         int limit = options.getLimit();
         int skip = options.getSkip();


### PR DESCRIPTION
AllDocQuery with Conflict needs to load document body. forestdb storage always loaded body because of JNI code bug. Yesterday, jens fixed it by https://github.com/couchbaselabs/cbforest/commit/600d8048945bbfcdf94a20ca43f0d6205cc1aa83 . By fixing cbforest, forestdb storage could not return revisions that have conflict.

Basically this fix makes loading body if query option contains show_conflict or only_conflict. This fix is equivalent with https://github.com/couchbase/couchbase-lite-ios/blob/master/Source/CBL_ForestDBStorage.mm#L585-L586
