### PR TITLE
Fix ForestDBStore.databaseExists

### DIFF
--- a/src/main/java/com/couchbase/lite/store/ForestDBStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBStore.java
@@ -126,7 +126,10 @@ public class ForestDBStore implements Store, EncryptableStore, Constants {
 
     @Override
     public boolean databaseExists(String directory) {
-        return new File(directory, kDBFilename).exists();
+        if (new File(directory, kDBFilename).exists())
+            return true;
+        // If "db.forest" doesn't exist (auto-compaction will add numeric suffixes), check for meta:
+        return new File(directory, kDBFilename + ".meta").exists();
     }
 
     @Override


### PR DESCRIPTION
If `db.forest` doesn't exist (auto-compaction will add numeric suffixes), need to check for meta. This logic is ported from the iOS implementation.

https://github.com/couchbase/couchbase-lite-java-core/issues/722
