### PR TITLE
Rename maven repository for android

### DIFF
--- a/build-android.gradle
+++ b/build-android.gradle
@@ -126,7 +126,7 @@ dependencies {
 task createMavenDirectory(type: Exec) {
     ext {
         uploadUser = System.getenv("MAVEN_UPLOAD_USERNAME") + ":" + System.getenv("MAVEN_UPLOAD_PASSWORD")
-        mkcolPath  = System.getenv("MAVEN_UPLOAD_REPO_URL") + "com/couchbase/lite/couchbase-lite-java-forestdb/" + version + "/"
+        mkcolPath  = System.getenv("MAVEN_UPLOAD_REPO_URL") + "com/couchbase/lite/couchbase-lite-android-forestdb/" + version + "/"
     }
     commandLine "curl", "--user", uploadUser, "-X", "MKCOL", mkcolPath
 }
@@ -148,7 +148,7 @@ uploadArchives {
             }
             pom.version = version
             pom.groupId = 'com.couchbase.lite'
-            pom.artifactId = 'couchbase-lite-java-forestdb'
+            pom.artifactId = 'couchbase-lite-android-forestdb'
             pom.project {
                 licenses {
                     license {


### PR DESCRIPTION
Renamed maven repository for android to couchbase-lite-android-forestdb.

https://github.com/couchbase/couchbase-lite-java-core/issues/858
