### PR TITLE
Fixed Java Core 924: viewname special chars

### DIFF
--- a/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
@@ -43,7 +43,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -705,15 +708,31 @@ public class ForestDBViewStore  implements ViewStore, QueryRowStore, Constants {
         if (fileName.startsWith("."))
             return null;
         String viewName = fileName.substring(0, fileName.indexOf("."));
-        viewName = viewName.replaceAll(":", "/");
+        try {
+            viewName = isWindows() ? URLDecoder.decode(viewName, "UTF-8") : viewName.replaceAll(":", "/");
+        }catch(UnsupportedEncodingException ex){
+            Log.w(TAG, "Error to url encode: " + viewName ,ex);
+        }
         return viewName;
     }
 
     private static String viewNameToFileName(String viewName) {
         if (viewName.startsWith(".") || viewName.indexOf(":") > 0)
             return null;
-        viewName = viewName.replaceAll("/", ":");
+        try {
+            viewName = isWindows() ? URLEncoder.encode(viewName, "UTF-8") : viewName.replaceAll("/", ":");
+        }catch(UnsupportedEncodingException ex){
+            Log.w(TAG, "Error to url decode: " + viewName, ex);
+        }
         return viewName + "." + kViewIndexPathExtension;
+    }
+
+
+
+    private static String OS = System.getProperty("os.name").toLowerCase();
+
+    private static boolean isWindows(){
+        return (OS.indexOf("win") >= 0);
     }
 
     /**

--- a/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
@@ -708,12 +708,7 @@ public class ForestDBViewStore  implements ViewStore, QueryRowStore, Constants {
             throw new CouchbaseLiteException(Status.BAD_PARAM);
 
         String viewName = fileName.substring(0, fileName.indexOf("."));
-        try {
-            viewName = isWindows() ? URLDecoder.decode(viewName, "UTF-8") : viewName.replaceAll(":", "/");
-        } catch (UnsupportedEncodingException ex) {
-            Log.w(TAG, "Error to url encode: " + viewName, ex);
-            throw new CouchbaseLiteException(ex, Status.BAD_ENCODING);
-        }
+        viewName = isWindows() ? unescapeViewNameWindows(viewName) : viewName.replaceAll(":", "/");
         return viewName;
     }
 
@@ -721,18 +716,32 @@ public class ForestDBViewStore  implements ViewStore, QueryRowStore, Constants {
         if (viewName.startsWith(".") || viewName.indexOf(":") > 0)
             throw new CouchbaseLiteException(Status.BAD_PARAM);
 
-        try {
-            viewName = isWindows() ? URLEncoder.encode(viewName, "UTF-8") : viewName.replaceAll("/", ":");
-        } catch (UnsupportedEncodingException ex) {
-            Log.w(TAG, "Error to url decode: " + viewName, ex);
-            throw new CouchbaseLiteException(ex, Status.BAD_ENCODING);
-        }
+        viewName = isWindows() ? escapeViewNameWindows(viewName) : viewName.replaceAll("/", ":");
 
         return viewName + "." + kViewIndexPathExtension;
     }
 
+    private static String escapeViewNameWindows(String viewName)throws CouchbaseLiteException {
+        try {
+            viewName = URLEncoder.encode(viewName, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            Log.w(TAG, "Error to url decode: " + viewName, e);
+            throw new CouchbaseLiteException(e, Status.BAD_ENCODING);
+        }
+        viewName = viewName.replaceAll("\\*", "%2A");
+        return viewName;
+    }
 
-
+    private static String unescapeViewNameWindows(String viewName)throws CouchbaseLiteException {
+        viewName = viewName.replaceAll("%2A", "*");
+        try {
+            viewName = URLDecoder.decode(viewName, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            Log.w(TAG, "Error to url decode: " + viewName, e);
+            throw new CouchbaseLiteException(e, Status.BAD_ENCODING);
+        }
+        return viewName;
+    }
     private static String OS = System.getProperty("os.name").toLowerCase();
 
     private static boolean isWindows(){

--- a/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
@@ -39,7 +39,6 @@ import com.couchbase.lite.support.action.ActionBlock;
 import com.couchbase.lite.support.action.ActionException;
 import com.couchbase.lite.support.security.SymmetricKey;
 import com.couchbase.lite.util.Log;
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.io.File;
 import java.io.IOException;
@@ -702,28 +701,33 @@ public class ForestDBViewStore  implements ViewStore, QueryRowStore, Constants {
     // Internal (Protected/Private) Static Methods
     ///////////////////////////////////////////////////////////////////////////
 
-    protected static String fileNameToViewName(String fileName) {
+    protected static String fileNameToViewName(String fileName) throws CouchbaseLiteException {
         if (!fileName.endsWith(kViewIndexPathExtension))
-            return null;
+            throw new CouchbaseLiteException(Status.BAD_PARAM);
         if (fileName.startsWith("."))
-            return null;
+            throw new CouchbaseLiteException(Status.BAD_PARAM);
+
         String viewName = fileName.substring(0, fileName.indexOf("."));
         try {
             viewName = isWindows() ? URLDecoder.decode(viewName, "UTF-8") : viewName.replaceAll(":", "/");
-        }catch(UnsupportedEncodingException ex){
-            Log.w(TAG, "Error to url encode: " + viewName ,ex);
+        } catch (UnsupportedEncodingException ex) {
+            Log.w(TAG, "Error to url encode: " + viewName, ex);
+            throw new CouchbaseLiteException(ex, Status.BAD_ENCODING);
         }
         return viewName;
     }
 
-    private static String viewNameToFileName(String viewName) {
+    private static String viewNameToFileName(String viewName) throws CouchbaseLiteException {
         if (viewName.startsWith(".") || viewName.indexOf(":") > 0)
-            return null;
+            throw new CouchbaseLiteException(Status.BAD_PARAM);
+
         try {
             viewName = isWindows() ? URLEncoder.encode(viewName, "UTF-8") : viewName.replaceAll("/", ":");
-        }catch(UnsupportedEncodingException ex){
+        } catch (UnsupportedEncodingException ex) {
             Log.w(TAG, "Error to url decode: " + viewName, ex);
+            throw new CouchbaseLiteException(ex, Status.BAD_ENCODING);
         }
+
         return viewName + "." + kViewIndexPathExtension;
     }
 


### PR DESCRIPTION
ForestDBViewStore uses view name as database name. However Windows has character limitation for folder name. If view name contains illegal characters, ForestDBViewStore uses URLEncode to encode view name to Windows friendly name. Asterisk is not encoded by URLEncoder. So it requires special treatment.
