### PR TITLE
Fixed Java Core 937 - Dead Lock in inTransaction

### DIFF
--- a/src/main/java/com/couchbase/lite/store/ForestDBStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBStore.java
@@ -256,7 +256,6 @@ public class ForestDBStore implements Store, EncryptableStore, Constants {
 
     @Override
     public boolean inTransaction() {
-        //return forest.isInTransaction();
         return transactionLevel4Thread.get() > 0;
     }
 


### PR DESCRIPTION
Problem:
- cbforest inTransaction acquires lock of database, then acquires lock for transaction. Other code could acquire lock for transaction, then acquires lock of database. this causes dead-lock.

Solution:
In case of enabling threadSafety for cbforest, needs to avoid to use inTransaction of cbforest. Instead of calling inTransaction, ForestDBStore maintain transactionLevel per thread.
