### PR TITLE
Fixed Android Issue 820 - Clone and build couchbase lite as sub modul…

### DIFF
--- a/build-android.gradle
+++ b/build-android.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 apply plugin: 'com.android.library'
 apply plugin: "maven"
 
@@ -91,7 +93,10 @@ android {
     // call regular ndk-build(.cmd) script from app directory
     task buildNative(type: Exec, description: 'Compile JNI source via NDK') {
         def ndkDir = android.ndkDirectory
-        commandLine "$ndkDir/ndk-build", '-C', file('jni').absolutePath
+        def ndkBuild = "$ndkDir/ndk-build"
+        if(Os.isFamily(Os.FAMILY_WINDOWS))
+            ndkBuild = "$ndkDir\\ndk-build.cmd"
+        commandLine "$ndkBuild", '-C', file('jni').absolutePath
     }
 
     buildNative.dependsOn 'generateCBForestJniHeaders'
@@ -103,7 +108,10 @@ android {
 
     task cleanNative(type: Exec, description: 'Clean JNI object files') {
         def ndkDir = android.ndkDirectory
-        commandLine "$ndkDir/ndk-build", '-C', file('jni').absolutePath, 'clean'
+        def ndkBuild = "$ndkDir/ndk-build"
+        if(Os.isFamily(Os.FAMILY_WINDOWS))
+            ndkBuild = "$ndkDir\\ndk-build.cmd"
+        commandLine "$ndkBuild", '-C', file('jni').absolutePath, 'clean'
     }
     cleanNative.dependsOn 'cleanJniHeaders'
     clean.dependsOn 'cleanNative'

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,34 +1,34 @@
 # File: Android.mk
 LOCAL_PATH := $(call my-dir)
+PARENT_LOCAL_PATH := $(wildcard ..)
+
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := libcrypto
-LOCAL_SRC_FILES := $(LOCAL_PATH)/../vendor/cbforest/vendor/openssl/libs/android/$(TARGET_ARCH_ABI)/libcrypto.a
+LOCAL_SRC_FILES := $(PARENT_LOCAL_PATH)/vendor/cbforest/vendor/openssl/libs/android/$(TARGET_ARCH_ABI)/libcrypto.a
 include $(PREBUILT_STATIC_LIBRARY)
-
 
 
 include $(CLEAR_VARS)
 
 LOCAL_MODULE	:=	CouchbaseLiteJavaForestDB
 
-FORESTDB_PATH   :=  $(LOCAL_PATH)/../vendor/cbforest/vendor/forestdb
-SNAPPY_PATH     :=  $(LOCAL_PATH)/../vendor/cbforest/vendor/snappy
-SQLITE3_PATH   	:=  $(LOCAL_PATH)/../vendor/cbforest/vendor/sqlite3-unicodesn
-SQLITE_INC_PATH :=  $(LOCAL_PATH)/../vendor/sqlite
-OPENSSL_PATH    :=  $(LOCAL_PATH)/../vendor/cbforest/vendor/openssl/libs/include
-CBFOREST_PATH   :=  $(LOCAL_PATH)/../vendor/cbforest/CBForest
-CBFOREST_C_PATH  :=  $(LOCAL_PATH)/../vendor/cbforest/C
-CBFOREST_JAVA_PATH  :=  $(LOCAL_PATH)/../vendor/cbforest/Java
-CBFOREST_JNI_PATH   :=  $(LOCAL_PATH)/../vendor/cbforest/Java/jni
-FORESTDB_STORE_PATH :=  $(LOCAL_PATH)/source
+FORESTDB_PATH   :=  $(PARENT_LOCAL_PATH)/vendor/cbforest/vendor/forestdb
+SNAPPY_PATH     :=  $(PARENT_LOCAL_PATH)/vendor/cbforest/vendor/snappy
+SQLITE3_PATH   	:=  $(PARENT_LOCAL_PATH)/vendor/cbforest/vendor/sqlite3-unicodesn
+SQLITE_INC_PATH :=  $(PARENT_LOCAL_PATH)/vendor/sqlite
+OPENSSL_PATH    :=  $(PARENT_LOCAL_PATH)/vendor/cbforest/vendor/openssl/libs/include
+CBFOREST_PATH   :=  $(PARENT_LOCAL_PATH)/vendor/cbforest/CBForest
+CBFOREST_C_PATH  :=  $(PARENT_LOCAL_PATH)/vendor/cbforest/C
+CBFOREST_JAVA_PATH  :=  $(PARENT_LOCAL_PATH)/vendor/cbforest/Java
+CBFOREST_JNI_PATH   :=  $(PARENT_LOCAL_PATH)/vendor/cbforest/Java/jni
+FORESTDB_STORE_PATH :=  $(PARENT_LOCAL_PATH)/jni/source
 
 LOCAL_CFLAGS    :=  -I$(SQLITE3_PATH)/libstemmer_c/runtime/ \
 					-I$(SQLITE3_PATH)/libstemmer_c/src_c/ \
 					-I$(SQLITE3_PATH)/ \
 					-I$(SQLITE_INC_PATH)/ \
 					-I$(OPENSSL_PATH)/
-
 
 # For sqlite3-unicodesn
 LOCAL_CFLAGS	+=	-DSQLITE_ENABLE_FTS4 \


### PR DESCRIPTION
…e Failure

https://github.com/couchbase/couchbase-lite-android/issues/820
- use ndk-build.cmd for Windows
- `..` (parent directory) does not work on windows platform. Use `$(wildcard ..)`
