### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-android/issues/933

### DIFF
--- a/src/main/java/com/couchbase/lite/store/ForestDBStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBStore.java
@@ -297,7 +297,7 @@ public class ForestDBStore implements Store, EncryptableStore, Constants {
                 commit = task.run();
             } catch (Exception e) {
                 commit = false;
-                Log.e(TAG, e.toString(), e);
+                Log.e(TAG, "[ForestDBStore.runInTransaction()] Error in TransactionalTask", e);
                 throw new RuntimeException(e);
             } finally {
                 endTransaction(commit);


### PR DESCRIPTION
NPE and RemoteRequestCompletionBlock in 1.3.0-12
- `Exception` could be `null` in `catch` block.
