### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-java-core/issues/1394

### DIFF
--- a/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
@@ -627,7 +627,15 @@ public class ForestDBViewStore implements ViewStore, QueryRowStore, Constants {
 
     private boolean deleteViewFiles() {
         closeIndex();
-        return FileDirUtils.deleteRecursive(new File(_path));
+        int flags = 0;
+        if(_dbStore.getAutoCompact())
+            flags |= Database.AutoCompact;
+        try {
+            return View.deleteAtPath(_path, flags);
+        } catch (ForestException e) {
+            Log.e(TAG, "error in deleteAtPath() _path=[%s]", e, _path);
+            return false;
+        }
     }
 
     private static String viewNames(List<ViewStore> views) {


### PR DESCRIPTION
Issue: ViewsTest.testDeleteView() test failure

Use native library's method to delete index file. With auto-compaction enabled, forestdb filename could have .0, .1, etc. It could fail to delete index file.

PR to cbforest: https://github.com/couchbaselabs/cbforest/pull/104
