### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-java-core/issues/1429

### DIFF
--- a/src/main/java/com/couchbase/lite/store/ForestDBStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBStore.java
@@ -915,7 +915,7 @@ public class ForestDBStore implements Store, EncryptableStore, Constants {
                     throw new CouchbaseLiteException(Status.DB_ERROR);
                 }
                 putRev.setSequence(doc.getSequence());
-                change = changeWithNewRevision(putRev, isWinner, doc, null);
+                change = changeWithNewRevision(putRev, isWinner, deleting, doc, null);
             } finally {
                 doc.free();
             }
@@ -1277,6 +1277,15 @@ public class ForestDBStore implements Store, EncryptableStore, Constants {
                                                  URL source) {
         String winningRevID = isWinningRev ? inRev.getRevID() : doc.getSelectedRevID();
         return new DocumentChange(inRev, winningRevID, doc.conflicted(), source);
+    }
+
+    private DocumentChange changeWithNewRevision(RevisionInternal inRev,
+                                                 boolean isWinningRev,
+                                                 boolean deleting,
+                                                 Document doc,
+                                                 URL source) {
+        String winningRevID = isWinningRev ? inRev.getRevID() : doc.getSelectedRevID();
+        return new DocumentChange(inRev, winningRevID, !deleting && !isWinningRev, source);
     }
 
     private boolean beginTransaction() {


### PR DESCRIPTION
Issue: DocumentChange of deleted conflicted rev shown as conflicted when using ForestDB

Problem:
- DocumentChange instance is created for every new revision. ForestDB store implementation checks if conflicting by doc.conflicted(). Like test case, two or more revisions are conflicting and delete one of conflicted revisions, the document is still conflicting.

Solution:
- SQLite store implementation set true if new revision is not delete and new rev is not winning rev. Applied same logic for forestdb store implementation.

Note:
- It is not clear for forceInsert(..) method. This change does not impact to forceInsert(...)
