### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-android/issues/967

### DIFF
--- a/src/main/java/com/couchbase/lite/store/ForestDBStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBStore.java
@@ -675,10 +675,6 @@ public class ForestDBStore implements Store, EncryptableStore, Constants {
                     if (!doc.conflicted() &&
                             options.getAllDocsMode() == Query.AllDocsMode.ONLY_CONFLICTS)
                         continue; // skip non-conflicted doc
-                    if (skip > 0) {
-                        --skip;
-                        continue;
-                    }
 
                     String revID = doc.getSelectedRevID();
                     long sequence = doc.getSelectedSequence();


### PR DESCRIPTION
Issue: query.setSkip() skip too much with forestdb 1.3.0

Problem: Skipped results both in native layer and Java layer.....
