### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-java-core/issues/1441

### DIFF
--- a/src/main/java/com/couchbase/lite/store/ForestDBStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBStore.java
@@ -642,8 +642,8 @@ public class ForestDBStore implements Store, EncryptableStore, Constants {
         // TODO: kCBLOnlyConflicts
 
         // No start or end ID:
+        DocumentIterator itr = null;
         try {
-            DocumentIterator itr;
             if (options.getKeys() != null) {
                 String[] docIDs = options.getKeys().toArray(new String[options.getKeys().size()]);
                 iteratorFlags |= IteratorFlags.kIncludeDeleted;
@@ -722,12 +722,16 @@ public class ForestDBStore implements Store, EncryptableStore, Constants {
                     if (limit > 0 && --limit == 0)
                         break;
                 } finally {
-                    doc.free();
+                    if (doc != null)
+                        doc.free();
                 }
             }
         } catch (ForestException e) {
             Log.e(TAG, "Error in getAllDocs()", e);
             return null;
+        } finally {
+            if (itr != null)
+                itr.close();
         }
 
         result.put("rows", rows);


### PR DESCRIPTION
Title: ForestDB: Query.setLimit() could cause crashes.

Description: In case forestdb store is already closed when closing forestdb iterator, fdb_iterator_close() causes crash. This scenario could be happen because DocumentIterator.free(handle) is called from finalize(). To avoid this scenario, DocumentIterator should provide public void close() method to allow Java codes close DocumentIterator explicitly.
