### PR TITLE
Fixed Java Core Issue 1535 - NPE with do_GET_DesignDocument

### DIFF
--- a/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
+++ b/src/main/java/com/couchbase/lite/store/ForestDBViewStore.java
@@ -411,7 +411,10 @@ public class ForestDBViewStore implements ViewStore, QueryRowStore, Constants {
                         // #Linked_documents
                         String linkedRev = (String) ((Map) value).get("_rev");
                         docRevision = _dbStore.getDocument(linkedID, linkedRev, true);
-                        sequence = docRevision.getSequence();
+                        if (docRevision != null)
+                            sequence = docRevision.getSequence();
+                        else
+                            Log.w(TAG, "Couldn't load linked doc %s rev %s", linkedID, linkedRev);
                     } else {
                         docRevision = _dbStore.getDocument(docID, null, true);
                     }


### PR DESCRIPTION
ForestDB Views Issue :Router: Router unable to route request to do_GET_DesignDocument(java.lang.NullPointerException)
https://github.com/couchbase/couchbase-lite-java-core/issues/1535

- Need to check if docRevision is null. If it is null, print warning message